### PR TITLE
Upgrade golangci-lint version to v1.31

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -46,7 +46,6 @@
     "noctx", # Too strict
     "exhaustive", # Too strict
     "nlreturn", # Too strict
-    "exportloopref", # Too strict
   ]
 
 [issues]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/traefik/mesh
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.30.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.31.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -563,7 +563,7 @@ func addStubDomain(config, blockHeader, blockTrailer, domain, clusterDomain, tra
 
 	stubDomain := fmt.Sprintf(stubDomainFormat,
 		clusterDomain,
-		strings.Replace(clusterDomain, ".", "\\.", -1),
+		strings.ReplaceAll(clusterDomain, ".", "\\."),
 		traefikMeshNamespace,
 		blockHeader,
 		blockTrailer,

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -554,7 +554,9 @@ func buildHTTPRouteGroupMatches(ttMatches []string, httpRouteGroupMatches []spec
 			found = match.Name == name
 
 			if found {
+				match := match
 				httpMatches = append(httpMatches, &match)
+
 				break
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Upgrades golangci-lint version to v1.31

### How to test it

* make check