### PR TITLE
Upgrade Traefik dependency version to v2.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	github.com/traefik/paerser v0.1.0
-	github.com/traefik/traefik/v2 v2.3.0-rc6
+	github.com/traefik/traefik/v2 v2.3.0
 	github.com/vdemeester/shakers v0.1.0
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -728,8 +728,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/traefik/paerser v0.1.0 h1:B4v1tbvd8YnHsA7spwHKEWJoGrRP+2jYpIozsCMHhl0=
 github.com/traefik/paerser v0.1.0/go.mod h1:yYnAgdEC2wJH5CgG75qGWC8SsFDEapg09o9RrA6FfrE=
-github.com/traefik/traefik/v2 v2.3.0-rc6 h1:B1+uYaP9cyscs1K9+SQ2rJYO6BVoY18JwNKMzorF4vQ=
-github.com/traefik/traefik/v2 v2.3.0-rc6/go.mod h1:CAemATo18BZPU8YbSRDLF/Q9v7W52WnRblbo2/BsizM=
+github.com/traefik/traefik/v2 v2.3.0 h1:CDeAq2CASBUd+QO4BX9GR7qbKMcMlByIwc6RO1fikMA=
+github.com/traefik/traefik/v2 v2.3.0/go.mod h1:CAemATo18BZPU8YbSRDLF/Q9v7W52WnRblbo2/BsizM=
 github.com/traefik/yaegi v0.9.0/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
 github.com/transip/gotransip/v6 v6.2.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
## What does this PR do?

This PR upgrades the Traefik dependency version to `v2.3.0`

### How to test it

* make test
* make test-integration