### PR TITLE
Remove smi flag

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -13,7 +13,6 @@ type TraefikMeshConfiguration struct {
 	LogFormat        string   `description:"The log format." export:"true"`
 	Debug            bool     `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	ACL              bool     `description:"Enable ACL mode." export:"true"`
-	SMI              bool     `description:"Enable SMI operation, deprecated, use --acl instead." export:"true"`
 	DefaultMode      string   `description:"Default mode for mesh services." export:"true"`
 	Namespace        string   `description:"The namespace that Traefik Mesh is installed in." export:"true"`
 	WatchNamespaces  []string `description:"Namespaces to watch." export:"true"`
@@ -34,7 +33,6 @@ func NewTraefikMeshConfiguration() *TraefikMeshConfiguration {
 		LogFormat:     "common",
 		Debug:         false,
 		ACL:           false,
-		SMI:           false,
 		DefaultMode:   "http",
 		Namespace:     "maesh",
 		APIPort:       9000,
@@ -55,7 +53,6 @@ type PrepareConfiguration struct {
 	Debug         bool   `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	Namespace     string `description:"The namespace that Traefik Mesh is installed in." export:"true"`
 	ClusterDomain string `description:"Your internal K8s cluster domain." export:"true"`
-	SMI           bool   `description:"Enable SMI operation, deprecated, use --acl instead." export:"true"`
 	ACL           bool   `description:"Enable ACL mode." export:"true"`
 }
 
@@ -68,7 +65,6 @@ func NewPrepareConfiguration() *PrepareConfiguration {
 		Debug:         false,
 		Namespace:     "maesh",
 		ClusterDomain: "cluster.local",
-		SMI:           false,
 	}
 }
 

--- a/cmd/mesh/mesh.go
+++ b/cmd/mesh/mesh.go
@@ -82,12 +82,7 @@ func traefikMeshCommand(config *cmd.TraefikMeshConfiguration) error {
 		return fmt.Errorf("error building clients: %w", err)
 	}
 
-	if config.SMI {
-		log.Warn("SMI mode is deprecated, please consider using --acl instead")
-	}
-
-	aclEnabled := config.ACL || config.SMI
-	log.Debugf("ACL mode enabled: %t", aclEnabled)
+	log.Debugf("ACL mode enabled: %t", config.ACL)
 
 	apiServer, err := api.NewAPI(log, config.APIPort, config.APIHost, clients.KubernetesClient(), config.Namespace)
 	if err != nil {
@@ -95,7 +90,7 @@ func traefikMeshCommand(config *cmd.TraefikMeshConfiguration) error {
 	}
 
 	ctr := controller.NewMeshController(clients, controller.Config{
-		ACLEnabled:       aclEnabled,
+		ACLEnabled:       config.ACL,
 		DefaultMode:      config.DefaultMode,
 		Namespace:        config.Namespace,
 		WatchNamespaces:  config.WatchNamespaces,

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -43,15 +43,9 @@ func prepareCommand(pConfig *cmd.PrepareConfiguration) error {
 
 	dnsClient := dns.NewClient(log, client.KubernetesClient())
 
-	if pConfig.SMI {
-		log.Warnf("SMI mode is deprecated, please consider using --acl instead")
-	}
+	log.Debugf("ACL mode enabled: %t", pConfig.ACL)
 
-	aclEnabled := pConfig.ACL || pConfig.SMI
-
-	log.Debugf("ACL mode enabled: %t", aclEnabled)
-
-	if err = k8s.CheckSMIVersion(client.KubernetesClient(), aclEnabled); err != nil {
+	if err = k8s.CheckSMIVersion(client.KubernetesClient(), pConfig.ACL); err != nil {
 		return fmt.Errorf("unsupported SMI version: %w", err)
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -23,9 +23,9 @@ const (
 
 type storeMock struct{}
 
-func (a *storeMock) SetConfig(cfg *dynamic.Configuration) {}
-func (a *storeMock) SetTopology(topo *topology.Topology)  {}
-func (a *storeMock) SetReadiness(isReady bool)            {}
+func (a *storeMock) SetConfig(_ *dynamic.Configuration) {}
+func (a *storeMock) SetTopology(_ *topology.Topology)   {}
+func (a *storeMock) SetReadiness(_ bool)                {}
 
 func TestController_NewMeshController(t *testing.T) {
 	store := &storeMock{}
@@ -35,7 +35,7 @@ func TestController_NewMeshController(t *testing.T) {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(logrus.DebugLevel)
 
-	// Create a new controller with base HTTP mode.
+	// Create a new controller with HTTP as a default traffic type.
 	controller := NewMeshController(clientMock, Config{
 		ACLEnabled:       false,
 		DefaultMode:      "http",
@@ -52,7 +52,7 @@ func TestController_NewMeshController(t *testing.T) {
 	assert.NotNil(t, controller)
 }
 
-func TestController_NewMeshControllerWithSMI(t *testing.T) {
+func TestController_NewMeshControllerWithACLEnabled(t *testing.T) {
 	store := &storeMock{}
 	clientMock := k8s.NewClientMock(t, "mock.yaml")
 	log := logrus.New()
@@ -60,7 +60,7 @@ func TestController_NewMeshControllerWithSMI(t *testing.T) {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(logrus.DebugLevel)
 
-	// Create a new controller with base HTTP mode, in SMI mode.
+	// Create a new controller with HTTP as a default traffic type and ACL enabled.
 	controller := NewMeshController(clientMock, Config{
 		ACLEnabled:       true,
 		DefaultMode:      "http",


### PR DESCRIPTION
## What does this PR do?

This PR removes the `smi` flag which is now deprecated since v1.2.

### How to test it

* make test
* make test-integration