### PR TITLE
Remove deprecated debug flag

### DIFF
--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -26,7 +26,7 @@ func NewCmd(cConfig *cmd.CleanupConfiguration, loaders []cli.ResourceLoader) *cl
 func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 	ctx := cmd.ContextWithSignal(context.Background())
 
-	logger, err := cmd.NewLogger(cConfig.LogFormat, cConfig.LogLevel, false)
+	logger, err := cmd.NewLogger(cConfig.LogFormat, cConfig.LogLevel)
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)
 	}

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -11,7 +11,6 @@ type TraefikMeshConfiguration struct {
 	MasterURL        string   `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
 	LogLevel         string   `description:"The log level." export:"true"`
 	LogFormat        string   `description:"The log format." export:"true"`
-	Debug            bool     `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	ACL              bool     `description:"Enable ACL mode." export:"true"`
 	DefaultMode      string   `description:"Default mode for mesh services." export:"true"`
 	Namespace        string   `description:"The namespace that Traefik Mesh is installed in." export:"true"`
@@ -31,7 +30,6 @@ func NewTraefikMeshConfiguration() *TraefikMeshConfiguration {
 		KubeConfig:    os.Getenv("KUBECONFIG"),
 		LogLevel:      "error",
 		LogFormat:     "common",
-		Debug:         false,
 		ACL:           false,
 		DefaultMode:   "http",
 		Namespace:     "maesh",
@@ -50,7 +48,6 @@ type PrepareConfiguration struct {
 	MasterURL     string `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
 	LogLevel      string `description:"The log level." export:"true"`
 	LogFormat     string `description:"The log format." export:"true"`
-	Debug         bool   `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	Namespace     string `description:"The namespace that Traefik Mesh is installed in." export:"true"`
 	ClusterDomain string `description:"Your internal K8s cluster domain." export:"true"`
 	ACL           bool   `description:"Enable ACL mode." export:"true"`
@@ -62,7 +59,6 @@ func NewPrepareConfiguration() *PrepareConfiguration {
 		KubeConfig:    os.Getenv("KUBECONFIG"),
 		LogLevel:      "error",
 		LogFormat:     "common",
-		Debug:         false,
 		Namespace:     "maesh",
 		ClusterDomain: "cluster.local",
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -24,20 +24,13 @@ func parseLogFormat(format string) (logrus.Formatter, error) {
 	}
 }
 
-// NewLogger returns a new field logger with the provided format, level, and debug configurations.
-func NewLogger(format, level string, debug bool) (logrus.FieldLogger, error) {
+// NewLogger returns a new field logger with the provided format and level.
+func NewLogger(format, level string) (logrus.FieldLogger, error) {
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
 
-	logLevelStr := level
-	if debug {
-		logLevelStr = "debug"
-
-		log.Warnf("Debug flag is deprecated, please consider using --loglevel=DEBUG instead")
-	}
-
-	logLevel, err := parseLogLevel(logLevelStr)
+	logLevel, err := parseLogLevel(level)
 	if err != nil {
 		return log, err
 	}

--- a/cmd/mesh/mesh.go
+++ b/cmd/mesh/mesh.go
@@ -68,7 +68,7 @@ func main() {
 func traefikMeshCommand(config *cmd.TraefikMeshConfiguration) error {
 	ctx := cmd.ContextWithSignal(context.Background())
 
-	log, err := cmd.NewLogger(config.LogFormat, config.LogLevel, config.Debug)
+	log, err := cmd.NewLogger(config.LogFormat, config.LogLevel)
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)
 	}

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -27,7 +27,7 @@ func NewCmd(pConfig *cmd.PrepareConfiguration, loaders []cli.ResourceLoader) *cl
 func prepareCommand(pConfig *cmd.PrepareConfiguration) error {
 	ctx := cmd.ContextWithSignal(context.Background())
 
-	log, err := cmd.NewLogger(pConfig.LogFormat, pConfig.LogLevel, pConfig.Debug)
+	log, err := cmd.NewLogger(pConfig.LogFormat, pConfig.LogLevel)
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR removes the --debug deprecated flag.

Fixes #748

<!-- A brief description of the change being made with this pull request. -->

### How to test it

* `make test`