### PR TITLE
Return an error if the API or controller stops unexpectedly

### DIFF
--- a/cmd/mesh/mesh.go
+++ b/cmd/mesh/mesh.go
@@ -67,23 +67,23 @@ func main() {
 func traefikMeshCommand(config *Configuration) error {
 	ctx := cmd.ContextWithSignal(context.Background())
 
-	log, err := cmd.NewLogger(config.LogFormat, config.LogLevel)
+	logger, err := cmd.NewLogger(config.LogFormat, config.LogLevel)
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)
 	}
 
-	log.Debug("Starting controller...")
-	log.Debugf("Using masterURL: %q", config.MasterURL)
-	log.Debugf("Using kubeconfig: %q", config.KubeConfig)
+	logger.Debug("Starting controller...")
+	logger.Debugf("Using masterURL: %q", config.MasterURL)
+	logger.Debugf("Using kubeconfig: %q", config.KubeConfig)
 
-	clients, err := k8s.NewClient(log, config.MasterURL, config.KubeConfig)
+	clients, err := k8s.NewClient(logger, config.MasterURL, config.KubeConfig)
 	if err != nil {
 		return fmt.Errorf("error building clients: %w", err)
 	}
 
-	log.Debugf("ACL mode enabled: %t", config.ACL)
+	logger.Debugf("ACL mode enabled: %t", config.ACL)
 
-	apiServer, err := api.NewAPI(log, config.APIPort, config.APIHost, clients.KubernetesClient(), config.Namespace)
+	apiServer, err := api.NewAPI(logger, config.APIPort, config.APIHost, clients.KubernetesClient(), config.Namespace)
 	if err != nil {
 		return fmt.Errorf("unable to create the API server: %w", err)
 	}
@@ -100,7 +100,7 @@ func traefikMeshCommand(config *Configuration) error {
 		MaxTCPPort:       getMaxPort(minTCPPort, config.LimitTCPPort),
 		MinUDPPort:       minUDPPort,
 		MaxUDPPort:       getMaxPort(minUDPPort, config.LimitUDPPort),
-	}, apiServer, log)
+	}, apiServer, logger)
 
 	var wg sync.WaitGroup
 
@@ -140,7 +140,7 @@ func traefikMeshCommand(config *Configuration) error {
 
 	case err := <-ctrlErrCh:
 		if stopErr := stopAPIServer(apiServer); stopErr != nil {
-			log.Errorf("Unable to stop the API server: %v", stopErr)
+			logger.Errorf("Unable to stop the API server: %v", stopErr)
 		}
 
 		return err

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -27,23 +27,23 @@ func NewCmd(config *Configuration, loaders []cli.ResourceLoader) *cli.Command {
 func prepareCommand(config *Configuration) error {
 	ctx := cmd.ContextWithSignal(context.Background())
 
-	log, err := cmd.NewLogger(config.LogFormat, config.LogLevel)
+	logger, err := cmd.NewLogger(config.LogFormat, config.LogLevel)
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)
 	}
 
-	log.Debug("Starting prepare...")
-	log.Debugf("Using masterURL: %q", config.MasterURL)
-	log.Debugf("Using kubeconfig: %q", config.KubeConfig)
+	logger.Debug("Starting prepare...")
+	logger.Debugf("Using masterURL: %q", config.MasterURL)
+	logger.Debugf("Using kubeconfig: %q", config.KubeConfig)
 
-	client, err := k8s.NewClient(log, config.MasterURL, config.KubeConfig)
+	client, err := k8s.NewClient(logger, config.MasterURL, config.KubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes client: %w", err)
 	}
 
-	dnsClient := dns.NewClient(log, client.KubernetesClient())
+	dnsClient := dns.NewClient(logger, client.KubernetesClient())
 
-	log.Debugf("ACL mode enabled: %t", config.ACL)
+	logger.Debugf("ACL mode enabled: %t", config.ACL)
 
 	if err = k8s.CheckSMIVersion(client.KubernetesClient(), config.ACL); err != nil {
 		return fmt.Errorf("unsupported SMI version: %w", err)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -18,13 +18,13 @@ import (
 var localhost = "127.0.0.1"
 
 func TestEnableReadiness(t *testing.T) {
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	client := fake.NewSimpleClientset()
-	api, err := NewAPI(log, 9000, localhost, client, "foo")
+	api, err := NewAPI(logger, 9000, localhost, client, "foo")
 
 	require.NoError(t, err)
 	assert.Equal(t, false, api.readiness.Get().(bool))
@@ -56,13 +56,14 @@ func TestGetReadiness(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			log := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger := logrus.New()
+
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			client := fake.NewSimpleClientset()
-			api, err := NewAPI(log, 9000, localhost, client, "foo")
+			api, err := NewAPI(logger, 9000, localhost, client, "foo")
 
 			require.NoError(t, err)
 			api.readiness.Set(test.readiness)
@@ -83,13 +84,13 @@ func TestGetReadiness(t *testing.T) {
 }
 
 func TestGetCurrentConfiguration(t *testing.T) {
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	client := fake.NewSimpleClientset()
-	api, err := NewAPI(log, 9000, localhost, client, "foo")
+	api, err := NewAPI(logger, 9000, localhost, client, "foo")
 
 	require.NoError(t, err)
 	api.configuration.Set("foo")
@@ -139,13 +140,14 @@ func TestGetMeshNodes(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			log := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger := logrus.New()
+
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			clientMock := k8s.NewClientMock(t, test.mockFile)
-			api, err := NewAPI(log, 9000, localhost, clientMock.KubernetesClient(), "foo")
+			api, err := NewAPI(logger, 9000, localhost, clientMock.KubernetesClient(), "foo")
 
 			require.NoError(t, err)
 
@@ -192,13 +194,13 @@ func TestGetMeshNodeConfiguration(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			clientMock := k8s.NewClientMock(t, test.mockFile)
-			api, err := NewAPI(log, 9000, localhost, clientMock.KubernetesClient(), "foo")
+			api, err := NewAPI(logger, 9000, localhost, clientMock.KubernetesClient(), "foo")
 
 			require.NoError(t, err)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -30,10 +30,10 @@ func (a *storeMock) SetReadiness(_ bool)                {}
 func TestController_NewMeshController(t *testing.T) {
 	store := &storeMock{}
 	clientMock := k8s.NewClientMock(t, "mock.yaml")
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	// Create a new controller with HTTP as a default traffic type.
 	controller := NewMeshController(clientMock, Config{
@@ -47,7 +47,7 @@ func TestController_NewMeshController(t *testing.T) {
 		MaxTCPPort:       maxTCPPort,
 		MinUDPPort:       minUDPPort,
 		MaxUDPPort:       maxUDPPort,
-	}, store, log)
+	}, store, logger)
 
 	assert.NotNil(t, controller)
 }
@@ -55,10 +55,10 @@ func TestController_NewMeshController(t *testing.T) {
 func TestController_NewMeshControllerWithACLEnabled(t *testing.T) {
 	store := &storeMock{}
 	clientMock := k8s.NewClientMock(t, "mock.yaml")
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	// Create a new controller with HTTP as a default traffic type and ACL enabled.
 	controller := NewMeshController(clientMock, Config{
@@ -72,7 +72,7 @@ func TestController_NewMeshControllerWithACLEnabled(t *testing.T) {
 		MaxTCPPort:       maxTCPPort,
 		MinUDPPort:       minUDPPort,
 		MaxUDPPort:       maxUDPPort,
-	}, store, log)
+	}, store, logger)
 
 	assert.NotNil(t, controller)
 }

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestEnqueueWorkHandler_OnAdd(t *testing.T) {
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-	handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+	handler := &enqueueWorkHandler{logger: logger, workQueue: workQueue}
 	handler.OnAdd(&corev1.Pod{})
 
 	assert.Equal(t, 1, workQueue.Len())
@@ -30,14 +30,14 @@ func TestEnqueueWorkHandler_OnAdd(t *testing.T) {
 }
 
 func TestEnqueueWorkHandler_OnDelete(t *testing.T) {
-	log := logrus.New()
+	logger := logrus.New()
 
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-	handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+	handler := &enqueueWorkHandler{logger: logger, workQueue: workQueue}
 	handler.OnDelete(&corev1.Pod{})
 
 	assert.Equal(t, 1, workQueue.Len())
@@ -78,14 +78,14 @@ func TestEnqueueWorkHandler_OnUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-			handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+			handler := &enqueueWorkHandler{logger: logger, workQueue: workQueue}
 			handler.OnUpdate(test.oldObj, test.newObj)
 
 			assert.Equal(t, test.expectedLen, workQueue.Len())
@@ -121,14 +121,14 @@ func TestEnqueueWorkHandler_enqueueWork(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-			handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+			handler := &enqueueWorkHandler{logger: logger, workQueue: workQueue}
 			handler.enqueueWork(test.obj)
 
 			assert.Equal(t, test.expectedLen, workQueue.Len())

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -228,10 +228,10 @@ func TestShadowServiceManager_CreateOrUpdate(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			currentShadowServices := make([]runtime.Object, 0)
 			if test.currentShadowSvc != nil {
@@ -258,7 +258,7 @@ func TestShadowServiceManager_CreateOrUpdate(t *testing.T) {
 			}
 
 			shadowServiceManager := NewShadowServiceManager(
-				log,
+				logger,
 				lister,
 				"traefik-mesh",
 				tcpPortMapperMock,
@@ -372,10 +372,10 @@ func TestShadowServiceManager_Delete(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			removedUDPPorts := make(map[servicePort]bool)
 			udpPortMapperMock := portMapperMock{
@@ -401,7 +401,7 @@ func TestShadowServiceManager_Delete(t *testing.T) {
 			client, lister := newFakeClient("v1.17", currentShadowServices...)
 
 			shadowServiceManager := NewShadowServiceManager(
-				log,
+				logger,
 				lister,
 				"traefik-mesh",
 				tcpPortMapperMock,
@@ -444,18 +444,15 @@ func TestShadowServiceManager_Delete(t *testing.T) {
 }
 
 func TestShadowServiceManager_getShadowServiceName(t *testing.T) {
-	name := "foo"
-	namespace := "bar"
+	logger := logrus.New()
 
-	log := logrus.New()
-
-	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.DebugLevel)
 
 	client, lister := newFakeClient("v1.17")
 
 	shadowServiceManager := NewShadowServiceManager(
-		log,
+		logger,
 		lister,
 		"traefik-mesh",
 		portMapperMock{},
@@ -466,7 +463,7 @@ func TestShadowServiceManager_getShadowServiceName(t *testing.T) {
 		client,
 	)
 
-	shadowSvcName := shadowServiceManager.getShadowServiceName(namespace, name)
+	shadowSvcName := shadowServiceManager.getShadowServiceName("bar", "foo")
 
 	assert.Equal(t, shadowSvcName, "traefik-mesh-foo-6d61657368-bar")
 }
@@ -491,10 +488,10 @@ func TestShadowServiceManager_getHTTPPort(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
 			client, lister := newFakeClient("v1.17")
 
@@ -502,7 +499,7 @@ func TestShadowServiceManager_getHTTPPort(t *testing.T) {
 			maxHTTPPort := int32(5002)
 
 			shadowServiceManager := NewShadowServiceManager(
-				log,
+				logger,
 				lister,
 				"traefik-mesh",
 				portMapperMock{},

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -53,12 +53,12 @@ func TestCheckDNSProvider(t *testing.T) {
 
 			k8sClient := k8s.NewClientMock(t, test.mockFile)
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
-			client := NewClient(log, k8sClient.KubernetesClient())
+			client := NewClient(logger, k8sClient.KubernetesClient())
 
 			provider, err := client.CheckDNSProvider(ctx)
 			if test.expErr {
@@ -160,12 +160,12 @@ func TestConfigureCoreDNS(t *testing.T) {
 
 			k8sClient := k8s.NewClientMock(t, test.mockFile)
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
-			client := NewClient(log, k8sClient.KubernetesClient())
+			client := NewClient(logger, k8sClient.KubernetesClient())
 
 			err := client.ConfigureCoreDNS(ctx, "kube-system", "titi", "toto")
 			if test.expErr {
@@ -236,12 +236,12 @@ func TestConfigureKubeDNS(t *testing.T) {
 
 			k8sClient := k8s.NewClientMock(t, test.mockFile)
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
-			client := NewClient(log, k8sClient.KubernetesClient())
+			client := NewClient(logger, k8sClient.KubernetesClient())
 
 			err := client.ConfigureKubeDNS(ctx, "cluster.local", "traefik-mesh")
 			if test.expErr {
@@ -297,12 +297,12 @@ func TestRestoreCoreDNS(t *testing.T) {
 
 			k8sClient := k8s.NewClientMock(t, test.mockFile)
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
-			client := NewClient(log, k8sClient.KubernetesClient())
+			client := NewClient(logger, k8sClient.KubernetesClient())
 
 			err := client.RestoreCoreDNS(ctx)
 			require.NoError(t, err)
@@ -351,12 +351,12 @@ func TestRestoreKubeDNS(t *testing.T) {
 
 			k8sClient := k8s.NewClientMock(t, test.mockFile)
 
-			log := logrus.New()
+			logger := logrus.New()
 
-			log.SetOutput(os.Stdout)
-			log.SetLevel(logrus.DebugLevel)
+			logger.SetOutput(os.Stdout)
+			logger.SetLevel(logrus.DebugLevel)
 
-			client := NewClient(log, k8sClient.KubernetesClient())
+			client := NewClient(logger, k8sClient.KubernetesClient())
 
 			err := client.RestoreKubeDNS(ctx)
 			require.NoError(t, err)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -33,28 +33,28 @@ type ClientWrapper struct {
 }
 
 // NewClient creates and returns a ClientWrapper that satisfies the Client interface.
-func NewClient(log logrus.FieldLogger, masterURL, kubeConfig string) (Client, error) {
-	config, err := buildConfig(log, masterURL, kubeConfig)
+func NewClient(logger logrus.FieldLogger, masterURL, kubeConfig string) (Client, error) {
+	config, err := buildConfig(logger, masterURL, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	kubeClient, err := buildKubernetesClient(log, config)
+	kubeClient, err := buildKubernetesClient(logger, config)
 	if err != nil {
 		return nil, err
 	}
 
-	accessClient, err := buildSmiAccessClient(log, config)
+	accessClient, err := buildSmiAccessClient(logger, config)
 	if err != nil {
 		return nil, err
 	}
 
-	specsClient, err := buildSmiSpecsClient(log, config)
+	specsClient, err := buildSmiSpecsClient(logger, config)
 	if err != nil {
 		return nil, err
 	}
 
-	splitClient, err := buildSmiSplitClient(log, config)
+	splitClient, err := buildSmiSplitClient(logger, config)
 	if err != nil {
 		return nil, err
 	}
@@ -68,15 +68,15 @@ func NewClient(log logrus.FieldLogger, masterURL, kubeConfig string) (Client, er
 }
 
 // buildConfig takes the master URL and kubeconfig, and returns an external or internal config.
-func buildConfig(log logrus.FieldLogger, masterURL, kubeConfig string) (*rest.Config, error) {
+func buildConfig(logger logrus.FieldLogger, masterURL, kubeConfig string) (*rest.Config, error) {
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
 		// If these env vars are set, we can build an in-cluster config.
-		log.Debug("Creating in-cluster client")
+		logger.Debug("Creating in-cluster client")
 		return rest.InClusterConfig()
 	}
 
 	if masterURL != "" || kubeConfig != "" {
-		log.Debug("Creating cluster-external client from provided masterURL or kubeconfig")
+		logger.Debug("Creating cluster-external client from provided masterURL or kubeconfig")
 		return clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
 	}
 
@@ -104,8 +104,8 @@ func (w *ClientWrapper) SplitClient() splitclient.Interface {
 }
 
 // buildClient returns a useable kubernetes client.
-func buildKubernetesClient(log logrus.FieldLogger, config *rest.Config) (*kubernetes.Clientset, error) {
-	log.Debug("Building Kubernetes Client...")
+func buildKubernetesClient(logger logrus.FieldLogger, config *rest.Config) (*kubernetes.Clientset, error) {
+	logger.Debug("Building Kubernetes Client...")
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -116,8 +116,8 @@ func buildKubernetesClient(log logrus.FieldLogger, config *rest.Config) (*kubern
 }
 
 // buildSmiAccessClient returns a client to manage SMI Access objects.
-func buildSmiAccessClient(log logrus.FieldLogger, config *rest.Config) (*accessclient.Clientset, error) {
-	log.Debug("Building SMI Access Client...")
+func buildSmiAccessClient(logger logrus.FieldLogger, config *rest.Config) (*accessclient.Clientset, error) {
+	logger.Debug("Building SMI Access Client...")
 
 	client, err := accessclient.NewForConfig(config)
 	if err != nil {
@@ -128,8 +128,8 @@ func buildSmiAccessClient(log logrus.FieldLogger, config *rest.Config) (*accessc
 }
 
 // buildSmiSpecsClient returns a client to manage SMI Specs objects.
-func buildSmiSpecsClient(log logrus.FieldLogger, config *rest.Config) (*specsclient.Clientset, error) {
-	log.Debug("Building SMI Specs Client...")
+func buildSmiSpecsClient(logger logrus.FieldLogger, config *rest.Config) (*specsclient.Clientset, error) {
+	logger.Debug("Building SMI Specs Client...")
 
 	client, err := specsclient.NewForConfig(config)
 	if err != nil {
@@ -140,8 +140,8 @@ func buildSmiSpecsClient(log logrus.FieldLogger, config *rest.Config) (*specscli
 }
 
 // buildSmiSplitClient returns a client to manage SMI Split objects.
-func buildSmiSplitClient(log logrus.FieldLogger, config *rest.Config) (*splitclient.Clientset, error) {
-	log.Debug("Building SMI Split Client...")
+func buildSmiSplitClient(logger logrus.FieldLogger, config *rest.Config) (*splitclient.Clientset, error) {
+	logger.Debug("Building SMI Split Client...")
 
 	client, err := splitclient.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

This PR:

- Returns an error to exit with a code greater than zero in case of a controller or API error.
- Renames all `log` fields, params and vars to `logger`.

Fixes #750 