### PR TITLE
Add Traefik Pilot to docs switcher menu

### DIFF
--- a/docs/theme/partials/product-switcher.html
+++ b/docs/theme/partials/product-switcher.html
@@ -12,7 +12,7 @@
 
     <div class="nav-dropdown-menu nav-dropdown-menu--products">
       <div class="nav-dropdown-menu-wrapper">
-        <div class="dm-header">Product Documentations</div>
+        <div class="dm-header">Product Documentation</div>
         <div class="dm-items">
 
           <div class="dm-item dm-item--traefik">
@@ -40,6 +40,19 @@
               <div class="dmi-description">
                 Ensure high availability, scalability, and security
                 of your microservices
+              </div>
+            </a>
+          </div>
+
+          <div class="dm-item dm-item--pilot">
+            <div class="dmi-image pilot">
+              <img src="{{ 'assets/images/traefik-pilot-logo.svg' | url }}" alt="Traefik Pilot Documentation" />
+            </div>
+            <a class="dmi-details" href="https://doc.traefik.io/traefik-pilot/">
+              <div class="dmi-title">Traefik Pilot</div>
+              <div class="dmi-description">
+                Monitor and Manage your Traefik Instances
+                <br>&nbsp;
               </div>
             </a>
           </div>


### PR DESCRIPTION
## What does this PR do?

- <!-- What does this PR do? -->

We now have a dedicated docs site for Traefik Pilot at https://doc.traefik.io/traefik-pilot/
This PR adds Pilot to the pull-down menu on the left of the documentation that allows users to easily switch between products.

<!-- A brief description of the change being made with this pull request. -->

### How to test it


## Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, etc.
 -->
