### PR TITLE
Deny HTTP traffic when no HTTPRouteGroup is given

### DIFF
--- a/integration/testdata/acl_enabled/http/6.traffic-target.yaml
+++ b/integration/testdata/acl_enabled/http/6.traffic-target.yaml
@@ -1,3 +1,13 @@
+apiVersion: specs.smi-spec.io/v1alpha3
+kind: HTTPRouteGroup
+metadata:
+  name: all
+  namespace: test
+spec:
+  matches:
+    - name: all
+      methods: ["*"]
+
 ---
 apiVersion: access.smi-spec.io/v1alpha2
 kind: TrafficTarget
@@ -13,3 +23,6 @@ spec:
     - kind: ServiceAccount
       name: tool-authorized
       namespace: test
+  rules:
+    - kind: HTTPRouteGroup
+      name: all

--- a/integration/testdata/acl_enabled/traffic-split/1.server-split.yaml
+++ b/integration/testdata/acl_enabled/traffic-split/1.server-split.yaml
@@ -103,6 +103,17 @@ spec:
       weight: 50
 
 ---
+apiVersion: specs.smi-spec.io/v1alpha3
+kind: HTTPRouteGroup
+metadata:
+  name: all
+  namespace: test
+spec:
+  matches:
+    - name: all
+      methods: ["*"]
+
+---
 apiVersion: access.smi-spec.io/v1alpha2
 kind: TrafficTarget
 metadata:
@@ -117,3 +128,6 @@ spec:
     - kind: ServiceAccount
       name: tool-authorized
       namespace: test
+  rules:
+    - kind: HTTPRouteGroup
+      name: all

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -312,6 +312,10 @@ func (p *Provider) buildServicesAndRoutersForTrafficTarget(t *topology.Topology,
 }
 
 func (p *Provider) buildHTTPServicesAndRoutersForTrafficTarget(t *topology.Topology, tt *topology.ServiceTrafficTarget, cfg *dynamic.Configuration, ttSvc *topology.Service, ttKey topology.ServiceTrafficTargetKey, scheme string, middlewares []string) {
+	if !hasTrafficTargetRuleHTTPRouteGroup(tt) {
+		return
+	}
+
 	whitelistDirect := p.buildWhitelistMiddlewareFromTrafficTargetDirect(t, tt)
 	whitelistDirectKey := getWhitelistMiddlewareKeyFromTrafficTargetDirect(tt)
 	cfg.HTTP.Middlewares[whitelistDirectKey] = whitelistDirect
@@ -917,6 +921,16 @@ func buildUDPRouter(entrypoint string, svcKey string) *dynamic.UDPRouter {
 func hasTrafficTargetRuleTCPRoute(tt *topology.ServiceTrafficTarget) bool {
 	for _, rule := range tt.Rules {
 		if rule.TCPRoute != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasTrafficTargetRuleHTTPRouteGroup(tt *topology.ServiceTrafficTarget) bool {
+	for _, rule := range tt.Rules {
+		if rule.HTTPRouteGroup != nil {
 			return true
 		}
 	}

--- a/pkg/provider/rule.go
+++ b/pkg/provider/rule.go
@@ -12,7 +12,11 @@ func buildHTTPRuleFromTrafficSpecs(specs []topology.TrafficSpec) string {
 	var orRules []string
 
 	for _, spec := range specs {
-		for _, match := range spec.HTTPMatches {
+		if spec.HTTPRouteGroup == nil {
+			continue
+		}
+
+		for _, match := range spec.HTTPRouteGroup.Spec.Matches {
 			var matchParts []string
 
 			// Handle Path filtering.
@@ -40,7 +44,7 @@ func buildHTTPRuleFromTrafficSpecs(specs []topology.TrafficSpec) string {
 	return strings.Join(orRules, " || ")
 }
 
-func appendPathFilter(matchParts []string, match *specs.HTTPMatch) []string {
+func appendPathFilter(matchParts []string, match specs.HTTPMatch) []string {
 	if match.PathRegex == "" {
 		return matchParts
 	}
@@ -53,7 +57,7 @@ func appendPathFilter(matchParts []string, match *specs.HTTPMatch) []string {
 	return append(matchParts, fmt.Sprintf("PathPrefix(`/{path:%s}`)", pathRegex))
 }
 
-func appendMethodFilter(matchParts []string, match *specs.HTTPMatch) []string {
+func appendMethodFilter(matchParts []string, match specs.HTTPMatch) []string {
 	if len(match.Methods) == 0 {
 		return matchParts
 	}
@@ -75,7 +79,7 @@ func appendMethodFilter(matchParts []string, match *specs.HTTPMatch) []string {
 	return matchParts
 }
 
-func appendHeaderFilter(matchParts []string, match *specs.HTTPMatch) []string {
+func appendHeaderFilter(matchParts []string, match specs.HTTPMatch) []string {
 	rules := make([]string, 0, len(match.Headers))
 
 	for name, value := range match.Headers {

--- a/pkg/provider/testdata/acl-enabled-http-basic-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-basic-topology.json
@@ -83,7 +83,27 @@
         "pods": [
           "pod-b@my-ns"
         ]
-      }
+      },
+      "rules": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "all",
+                  "methods": ["*"]
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   },
   "trafficSplits": {}

--- a/pkg/provider/testdata/acl-enabled-http-route-group-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-route-group-topology.json
@@ -90,14 +90,7 @@
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "app",
-              "methods": ["*"],
-              "pathRegex": "/app"
-            }
-          ]
+          }
         },
         {
           "httpRouteGroup": {
@@ -109,11 +102,6 @@
             },
             "spec": {
               "matches": [
-                {
-                  "name": "users",
-                  "methods": ["GET", "POST", "PUT"],
-                  "pathRegex": "/api/users"
-                },
                 {
                   "name": "notifications",
                   "methods": ["GET"],
@@ -129,22 +117,7 @@
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "notifications",
-              "methods": ["GET"],
-              "pathRegex": "/api/notifications"
-            },
-            {
-              "name": "firefox-beta",
-              "headers": [
-                {
-                  "User-Agent": "Mozilla/.*"
-                }
-              ]
-            }
-          ]
+          }
         }
       ]
     }

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
@@ -147,7 +147,27 @@
         "pods": [
           "pod-b@my-ns"
         ]
-      }
+      },
+      "rules": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "all",
+                  "methods": ["*"]
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "svc-c@my-ns:tt@my-ns": {
       "service": "svc-c@my-ns",
@@ -176,7 +196,27 @@
         "pods": [
           "pod-c@my-ns"
         ]
-      }
+      },
+      "rules": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "all",
+                  "methods": ["*"]
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
@@ -114,14 +114,7 @@
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "app",
-              "methods": ["*"],
-              "pathRegex": "/app"
-            }
-          ]
+          }
         }
       ]
     }

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-topology.json
@@ -126,7 +126,27 @@
         "pods": [
           "pod-b@my-ns"
         ]
-      }
+      },
+      "rules": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "all",
+                  "methods": ["*"]
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "svc-c@my-ns:tt@my-ns": {
       "service": "svc-c@my-ns",
@@ -155,7 +175,27 @@
         "pods": [
           "pod-c@my-ns"
         ]
-      }
+      },
+      "rules": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "all",
+                  "methods": ["*"]
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/pkg/topology/testdata/topology-traffic-split-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-split-traffic-target.json
@@ -218,27 +218,10 @@
                     "POST"
                   ],
                   "pathRegex": "/api"
-                },
-                {
-                  "name": "metric",
-                  "methods": [
-                    "GET"
-                  ],
-                  "pathRegex": "/metric"
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "api",
-              "methods": [
-                "GET",
-                "POST"
-              ],
-              "pathRegex": "/api"
-            }
-          ]
+          }
         }
       ],
       "errors": null
@@ -297,27 +280,10 @@
                     "POST"
                   ],
                   "pathRegex": "/api"
-                },
-                {
-                  "name": "metric",
-                  "methods": [
-                    "GET"
-                  ],
-                  "pathRegex": "/metric"
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "api",
-              "methods": [
-                "GET",
-                "POST"
-              ],
-              "pathRegex": "/api"
-            }
-          ]
+          }
         }
       ],
       "errors": null
@@ -369,27 +335,10 @@
                     "POST"
                   ],
                   "pathRegex": "/api"
-                },
-                {
-                  "name": "metric",
-                  "methods": [
-                    "GET"
-                  ],
-                  "pathRegex": "/metric"
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "api",
-              "methods": [
-                "GET",
-                "POST"
-              ],
-              "pathRegex": "/api"
-            }
-          ]
+          }
         }
       ],
       "errors": null
@@ -441,27 +390,10 @@
                     "POST"
                   ],
                   "pathRegex": "/api"
-                },
-                {
-                  "name": "metric",
-                  "methods": [
-                    "GET"
-                  ],
-                  "pathRegex": "/metric"
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "api",
-              "methods": [
-                "GET",
-                "POST"
-              ],
-              "pathRegex": "/api"
-            }
-          ]
+          }
         }
       ],
       "errors": null

--- a/pkg/topology/testdata/topology-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-target.json
@@ -97,32 +97,10 @@
                       "User-Agent": "curl/.*"
                     }
                   ]
-                },
-                {
-                  "name": "metric",
-                  "methods": [
-                    "GET"
-                  ],
-                  "pathRegex": "/metric"
                 }
               ]
             }
-          },
-          "httpMatches": [
-            {
-              "name": "api",
-              "methods": [
-                "GET",
-                "POST"
-              ],
-              "pathRegex": "/api",
-              "headers": [
-                {
-                  "User-Agent": "curl/.*"
-                }
-              ]
-            }
-          ]
+          }
         }
       ]
     }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -225,9 +225,6 @@ type TrafficSplit struct {
 type TrafficSpec struct {
 	HTTPRouteGroup *specs.HTTPRouteGroup `json:"httpRouteGroup,omitempty"`
 	TCPRoute       *specs.TCPRoute       `json:"tcpRoute,omitempty"`
-
-	// HTTPMatches is the list of HTTPMatch selected from the HTTPRouteGroup.
-	HTTPMatches []*specs.HTTPMatch `json:"httpMatches,omitempty"`
 }
 
 // AddError adds the given error to this TrafficSplit.


### PR DESCRIPTION
## What does this PR do?

This PR:
- Forbid HTTP traffic if the TrafficTarget doesn't contain an HTTPRouteGroup (according to the specification)
- Remove the HTTPMatches field of the ServiceTrafficTarget struct. Instead, the HTTPRouteGroup.Spec.Matches gets filtered out from every unwanted rules.

Fixes #747 

### How to test it

* `make test`
* Install traefik mesh with acl=true, apply a TrafficTarget with and without an HTTPRouteGroup.