### PR TITLE
Add supported SMI spec versions

### DIFF
--- a/docs/content/compatibility.md
+++ b/docs/content/compatibility.md
@@ -17,3 +17,13 @@ Please see the table below.
 |-----------------------|----------|----------|----------|
 | General functionality | ✔        | ✔        | ✔        |
 | Service Topology      | ✔        | ✔        | ✔        |
+
+## SMI Specification support
+
+Traefik Mesh is based on the latest version of the SMI specification:
+
+| API Group          | API Version                                                                                                             |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------|
+| access.smi-spec.io | [v1alpha2](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-access/v1alpha2/traffic-access.md) |
+| specs.smi-spec.io  | [v1alpha3](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-specs/v1alpha3/traffic-specs.md)   |
+| split.smi-spec.io  | [v1alpha3](https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-split/v1alpha3/traffic-split.md)   |


### PR DESCRIPTION
## What does this PR do?

This PR adds the supported SMI spec versions in the Compatibility page of the documentation.

Fixes #768