### PR TITLE
Allow CoreDNS version strings to contain sufixes

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -104,7 +104,7 @@ func (c *Client) coreDNSMatch(ctx context.Context) (bool, error) {
 	}
 
 	if !(version.GreaterThanOrEqual(versionCoreDNSMin) && version.LessThan(versionCoreDNSMax)) {
-		c.logger.Debugf("CoreDNS version is not supported, must satisfy >= %q, < %q, got %q", versionCoreDNSMin, versionCoreDNSMax, version)
+		c.logger.Debug(`CoreDNS version is not supported, must satisfy ">= %s, < %s", got %q`, versionCoreDNSMin, versionCoreDNSMax, version)
 
 		return false, fmt.Errorf("unsupported CoreDNS version %q", version)
 	}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -39,7 +39,12 @@ const (
 	traefikMeshBlockTrailer = "#### End Traefik Mesh Block"
 )
 
-var versionCoreDNS17 = goversion.Must(goversion.NewVersion("1.7"))
+var (
+	versionCoreDNS17 = goversion.Must(goversion.NewVersion("1.7"))
+
+	versionCoreDNSMin = goversion.Must(goversion.NewVersion("1.3"))
+	versionCoreDNSMax = goversion.Must(goversion.NewVersion("1.8"))
+)
 
 // Client holds the client for interacting with the k8s DNS system.
 type Client struct {
@@ -98,13 +103,8 @@ func (c *Client) coreDNSMatch(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	versionConstraint, err := goversion.NewConstraint(">= 1.3, < 1.8")
-	if err != nil {
-		return false, err
-	}
-
-	if !versionConstraint.Check(version) {
-		c.logger.Debugf("CoreDNS version is not supported, must satisfy %q, got %q", versionConstraint, version)
+	if !(version.GreaterThanOrEqual(versionCoreDNSMin) && version.LessThan(versionCoreDNSMax)) {
+		c.logger.Debugf("CoreDNS version is not supported, must satisfy >= %q, < %q, got %q", versionCoreDNSMin, versionCoreDNSMax, version)
 
 		return false, fmt.Errorf("unsupported CoreDNS version %q", version)
 	}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -104,7 +104,7 @@ func (c *Client) coreDNSMatch(ctx context.Context) (bool, error) {
 	}
 
 	if !(version.GreaterThanOrEqual(versionCoreDNSMin) && version.LessThan(versionCoreDNSMax)) {
-		c.logger.Debug(`CoreDNS version is not supported, must satisfy ">= %s, < %s", got %q`, versionCoreDNSMin, versionCoreDNSMax, version)
+		c.logger.Debugf(`CoreDNS version is not supported, must satisfy ">= %s, < %s", got %q`, versionCoreDNSMin, versionCoreDNSMax, version)
 
 		return false, fmt.Errorf("unsupported CoreDNS version %q", version)
 	}

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -27,6 +27,12 @@ func TestCheckDNSProvider(t *testing.T) {
 			expErr:      false,
 		},
 		{
+			desc:        "CoreDNS supported version with suffix",
+			mockFile:    "checkdnsprovider_supported_version_suffix.yaml",
+			expProvider: CoreDNS,
+			expErr:      false,
+		},
+		{
 			desc:        "KubeDNS",
 			mockFile:    "checkdnsprovider_kubedns.yaml",
 			expProvider: KubeDNS,

--- a/pkg/dns/testdata/checkdnsprovider_supported_version_suffix.yaml
+++ b/pkg/dns/testdata/checkdnsprovider_supported_version_suffix.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: coredns
+          image: image-registry.dkr.ecr.eu-west-1.amazonaws.com/eks/coredns:v1.6.6-eksbuild.1
+        - name: titi
+          image: titi/toto:latest


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the `traefik-mesh-controller/traefik-mesh-prepare` script would fail if the version of CoreDNS deployed in your environment contains a prefix. This has been seen on AWS EKS, where a build version is present (i.e: `v1.6.6-eksbuild.1`).

As described in the #773 issue, this is due to the way [hashicorp/go-version](github.com/hashicorp/go-version) handles version string when verified using `goversion.NewConstraint(">= 1.3, < 1.8")` as it considers any `-suffix` to be a pre-release version instead of a metadata (expecting a `+suffix` instead). This can be fixed by using the form `version.GreaterThanOrEqual("1.3") && version.LessThan("1.8")`.

Fixes #773

### How to test it

* Deploy an AWS EKS v1.17 environment (which would be deployed with CoreDNS v1.6.6-eksbuild.1)
* Deploy the `traefik-mesh` helm chart using this code, which should now be able to be deployed.

The specific use-case describe in the original issue has also been added as a test case in `pkg/dns/dns_test.go` for future reference.

## Additional Notes

This has been tested on an AWS EKS v1.17-eks.3 cluster with the default CNI removed and replaced by Calico.