### PR TITLE
fix: update goreleaser install link to use gist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/traefik/mesh
 RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.32.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.32.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache --no-progress add \
 WORKDIR /go/src/github.com/traefik/mesh
 
 # Download goreleaser binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.32.0

--- a/tmpl.Dockerfile
+++ b/tmpl.Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache --no-progress add \
 WORKDIR /go/src/github.com/traefik/mesh
 
 # Download goreleaser binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | sh
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./


### PR DESCRIPTION
### What does this PR do?

Since the recent release of [goreleaser](https://goreleaser.com) [v1.2.1](https://github.com/goreleaser/goreleaser/releases/tag/v1.2.1), the script to install it was removed.

This PR update the script to install goreleaser to use a gist instead.

### Motivation

Have a working CI.
