### PR TITLE
Fix CoreDNS Detection

### DIFF
--- a/integration/coredns_test.go
+++ b/integration/coredns_test.go
@@ -32,6 +32,8 @@ func (s *CoreDNSSuite) SetUpSuite(c *check.C) {
 		{Name: "coredns/coredns:1.5.2"},
 		{Name: "coredns/coredns:1.6.3"},
 		{Name: "coredns/coredns:1.7.0"},
+		{Name: "coredns/coredns:1.8.0"},
+		{Name: "coredns/coredns:1.9.0"},
 		{Name: "giantswarm/tiny-tools:3.9"},
 	}
 

--- a/integration/testdata/traefik-mesh/controller-acl-disabled.yaml
+++ b/integration/testdata/traefik-mesh/controller-acl-disabled.yaml
@@ -50,6 +50,7 @@ rules:
     resources:
       - deployments
     verbs:
+      - list
       - get
       - update
   - apiGroups:

--- a/integration/testdata/traefik-mesh/controller-acl-enabled.yaml
+++ b/integration/testdata/traefik-mesh/controller-acl-enabled.yaml
@@ -50,6 +50,7 @@ rules:
     resources:
       - deployments
     verbs:
+      - list
       - get
       - update
   - apiGroups:

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -93,6 +93,7 @@ func (c *Client) coreDNSMatch(ctx context.Context) (bool, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: "kubernetes.io/name=CoreDNS",
 	}
+
 	deployments, err := c.kubeClient.AppsV1().Deployments(metav1.NamespaceSystem).List(ctx, opts)
 	if err != nil {
 		return false, fmt.Errorf("unable to list CoreDNS deployments in namespace %q: %w", metav1.NamespaceSystem, err)

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -27,6 +27,12 @@ func TestCheckDNSProvider(t *testing.T) {
 			expErr:      false,
 		},
 		{
+			desc:        "CoreDNS supported version using label",
+			mockFile:    "checkdnsprovider_coredns_using_label.yaml",
+			expProvider: CoreDNS,
+			expErr:      false,
+		},
+		{
 			desc:        "CoreDNS supported version with suffix",
 			mockFile:    "checkdnsprovider_supported_version_suffix.yaml",
 			expProvider: CoreDNS,

--- a/pkg/dns/testdata/checkdnsprovider_coredns_using_label.yaml
+++ b/pkg/dns/testdata/checkdnsprovider_coredns_using_label.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rke2-coredns-rke2-coredns
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: CoreDNS
+spec:
+  template:
+    spec:
+      containers:
+        - name: coredns
+          image: image-registry.dkr.ecr.eu-west-1.amazonaws.com/eks/coredns:v1.8.4
+        - name: titi
+          image: titi/toto:latest


### PR DESCRIPTION
## What does this PR do?

This PR updates the CoreDNS detection. Previously we were only looking for the exact deployment name `coredns` in the `kube-system` namespace. The issue was that some Kubernetes distributions (RKE2 for example), use a different name for the CoreDNS deployment.

With this PR, we now look for a deployment having the label `kubernetes.io/name=CoreDNS`, which seems to be the case for most Kubernetes distributions. We still fall back to the old behavior if no deployment is found using the label because `kubeadm` does not add it for example (but it uses the default deployment name).

### How to test it

Unit tests have been updated to cover the new use-case.

## Additional notes

If we face more edge-cases like this one, we might want to consider adding a flag so users can directly set the name (and type?) of there DNS provider.