### PR TITLE
Fix publish-images step of release process

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Traefik Mesh Pipeline
 
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu1804
 
 auto_cancel:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,7 +89,7 @@ blocks:
 
       env_vars:
         - name: SEIHON_VERSION
-          value: v0.8.3
+          value: v0.9.0
 
       jobs:
         - name: Release

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ check: $(DIST_DIR)
       "$(DOCKER_IMAGE_NAME):check" golangci-lint run --config .golangci.toml
 
 publish-images: build
-	seihon publish -v "$(VERSION)" -v "latest" --image-name ${DOCKER_IMAGE_NAME} --dry-run=false --base-runtime-image=alpine:3.10
+	seihon publish -v "$(VERSION)" -v "latest" --image-name ${DOCKER_IMAGE_NAME} --dry-run=false --base-runtime-image=alpine:3.15
 
 ## Create packages for the release
 release-packages: vendor build


### PR DESCRIPTION
## What does this PR do?

This pull request fixes the `publish-images` step of the release process by upgrading the seihon version to `v0.9.0` and the base image to `alpine:3.15` as requested in https://github.com/traefik/mesh/pull/818.

It also increases the semaphore machine used for the build to avoid running out of space in the release process.  