### PR TITLE
Update golangci-lint to v1.48.0

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -37,6 +37,7 @@
 [linters]
   enable-all = true
   disable = [
+    "ifshort", # Deprecated
     "interfacer", # Deprecated
     "golint", # Deprecated
     "maligned", # Deprecated
@@ -56,6 +57,7 @@
     "noctx", # Too strict
     "exhaustive", # Too strict
     "exhaustivestruct", # Too strict
+    "exhaustruct", # Duplicate of exhaustivestruct
     "nlreturn", # Too strict
     "ireturn", # Not relevant
     "varnamelen", # Not relevant
@@ -63,6 +65,8 @@
     "testpackage", # Does not allow testing private funcs
     "tparallel", # Not relevant
     "paralleltest", # Not relevant
+    "forcetypeassert", # Too strict
+    "nonamedreturns", # Not relevant
     "funlen",
   ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/traefik/mesh
 RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.43.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.48.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -203,7 +204,7 @@ func (a *API) getMeshNodeConfiguration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://%s:8080/api/rawdata", pod.Status.PodIP))
+	resp, err := http.Get(fmt.Sprintf("http://%s/api/rawdata", net.JoinHostPort(pod.Status.PodIP, "8080")))
 	if err != nil {
 		a.log.Errorf("Unable to get configuration from pod %q: %v", pod.Name, err)
 		http.Error(w, "", http.StatusBadGateway)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -23,12 +23,12 @@ type PortFinder interface {
 
 // When multiple Traefik Routers listen to the same entrypoint and have the same Rule, the chosen router is the one
 // with the highest priority. There are a few cases where this priority is crucial when building the dynamic configuration:
-// - When a TrafficSplit is set on a k8s service, 2 Traefik Routers are created. One for accessing the k8s service
-//   endpoints and one for accessing the services endpoints mentioned in the TrafficSplit. They both have the same Rule
-//   but we should always prioritize the TrafficSplit. Therefore, TrafficSplit Routers should always have a higher priority.
-// - When a TrafficTarget Destination targets pods of a k8s service and a TrafficSplit is set on this service. This
-//   creates 2 Traefik Routers. One for the TrafficSplit and one for the TrafficTarget. We should always prioritize
-//   TrafficSplits Routers and TrafficSplit Routers should always have a higher priority than TrafficTarget Routers.
+//   - When a TrafficSplit is set on a k8s service, 2 Traefik Routers are created. One for accessing the k8s service
+//     endpoints and one for accessing the services endpoints mentioned in the TrafficSplit. They both have the same Rule
+//     but we should always prioritize the TrafficSplit. Therefore, TrafficSplit Routers should always have a higher priority.
+//   - When a TrafficTarget Destination targets pods of a k8s service and a TrafficSplit is set on this service. This
+//     creates 2 Traefik Routers. One for the TrafficSplit and one for the TrafficTarget. We should always prioritize
+//     TrafficSplits Routers and TrafficSplit Routers should always have a higher priority than TrafficTarget Routers.
 const (
 	priorityService = iota + 1
 	priorityTrafficTargetDirect


### PR DESCRIPTION
## What does this PR do?

This pull requests updates golangci-lint to `v1.48.0`.