### PR TITLE
Update k3d to v5.4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ tidy:
 	go mod tidy
 
 k3d:
-	@command -v k3d >/dev/null 2>&1 || curl -s https://raw.githubusercontent.com/rancher/k3d/v3.4.0/install.sh | TAG=v3.4.0 bash
+	@command -v k3d >/dev/null 2>&1 || curl -s https://raw.githubusercontent.com/rancher/k3d/v5.4.4/install.sh | TAG=v5.4.4 bash
 
 docs-package:
 	mkdir -p $(CURDIR)/pages

--- a/integration/acl_disabled_test.go
+++ b/integration/acl_disabled_test.go
@@ -25,9 +25,9 @@ func (s *ACLDisabledSuite) SetUpSuite(c *check.C) {
 	requiredImages := []k3d.DockerImage{
 		{Name: "traefik/mesh:latest", Local: true},
 		{Name: "traefik:v2.8"},
-		{Name: "traefik/whoami:v1.6.0"},
-		{Name: "traefik/whoamitcp:v0.1.0"},
-		{Name: "traefik/whoamiudp:v0.1.0"},
+		{Name: "traefik/whoami:v1.8.0"},
+		{Name: "traefik/whoamitcp:v0.2.1"},
+		{Name: "traefik/whoamiudp:v0.1.2"},
 		{Name: "giantswarm/tiny-tools:3.9"},
 	}
 
@@ -79,7 +79,7 @@ func (s *ACLDisabledSuite) TestTCPService(c *check.C) {
 
 // TestUDPService deploys a UDP service "server" with one Pod called "server" and asserts this service is
 // reachable and that a connection has been established with this Pod.
-func (s *ACLDisabledSuite) TestUDPervice(c *check.C) {
+func (s *ACLDisabledSuite) TestUDPService(c *check.C) {
 	c.Assert(s.cluster.Apply(s.logger, "testdata/acl_disabled/udp"), checker.IsNil)
 	defer s.cluster.Delete(s.logger, "testdata/acl_disabled/udp")
 

--- a/integration/acl_enabled_test.go
+++ b/integration/acl_enabled_test.go
@@ -23,18 +23,21 @@ type ACLEnabledSuite struct {
 func (s *ACLEnabledSuite) SetUpSuite(c *check.C) {
 	var err error
 
-	requiredImages := []k3d.DockerImage{
-		{Name: "traefik/mesh:latest", Local: true},
-		{Name: "traefik:v2.8"},
-		{Name: "traefik/whoami:v1.8.0"},
-		{Name: "giantswarm/tiny-tools:3.9"},
+	s.logger = logrus.New()
+
+	opts := []k3d.ClusterOptionFunc{
+		k3d.WithoutTraefik(),
+		k3d.WithImages(k3d.DockerImage{Name: "traefik/mesh:latest", Local: true}),
+	}
+	if !*disableImport {
+		opts = append(opts, k3d.WithImages(
+			k3d.DockerImage{Name: "traefik:v2.8"},
+			k3d.DockerImage{Name: "traefik/whoami:v1.8.0"},
+			k3d.DockerImage{Name: "giantswarm/tiny-tools:3.9"},
+		))
 	}
 
-	s.logger = logrus.New()
-	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName,
-		k3d.WithoutTraefik(),
-		k3d.WithImages(requiredImages...),
-	)
+	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName, opts...)
 	c.Assert(err, checker.IsNil)
 
 	c.Assert(s.cluster.CreateNamespace(s.logger, traefikMeshNamespace), checker.IsNil)

--- a/integration/acl_enabled_test.go
+++ b/integration/acl_enabled_test.go
@@ -26,7 +26,7 @@ func (s *ACLEnabledSuite) SetUpSuite(c *check.C) {
 	requiredImages := []k3d.DockerImage{
 		{Name: "traefik/mesh:latest", Local: true},
 		{Name: "traefik:v2.8"},
-		{Name: "traefik/whoami:v1.6.0"},
+		{Name: "traefik/whoami:v1.8.0"},
 		{Name: "giantswarm/tiny-tools:3.9"},
 	}
 

--- a/integration/coredns_test.go
+++ b/integration/coredns_test.go
@@ -26,7 +26,7 @@ func (s *CoreDNSSuite) SetUpSuite(c *check.C) {
 	var err error
 
 	requiredImages := []k3d.DockerImage{
-		{Name: "traefik/whoami:v1.6.0"},
+		{Name: "traefik/whoami:v1.8.0"},
 		{Name: "coredns/coredns:1.3.1"},
 		{Name: "coredns/coredns:1.4.0"},
 		{Name: "coredns/coredns:1.5.2"},

--- a/integration/coredns_test.go
+++ b/integration/coredns_test.go
@@ -25,23 +25,24 @@ type CoreDNSSuite struct {
 func (s *CoreDNSSuite) SetUpSuite(c *check.C) {
 	var err error
 
-	requiredImages := []k3d.DockerImage{
-		{Name: "traefik/whoami:v1.8.0"},
-		{Name: "coredns/coredns:1.3.1"},
-		{Name: "coredns/coredns:1.4.0"},
-		{Name: "coredns/coredns:1.5.2"},
-		{Name: "coredns/coredns:1.6.3"},
-		{Name: "coredns/coredns:1.7.0"},
-		{Name: "coredns/coredns:1.8.0"},
-		{Name: "coredns/coredns:1.9.0"},
-		{Name: "giantswarm/tiny-tools:3.9"},
+	s.logger = logrus.New()
+
+	opts := []k3d.ClusterOptionFunc{k3d.WithoutTraefik()}
+	if !*disableImport {
+		opts = append(opts, k3d.WithImages(
+			k3d.DockerImage{Name: "traefik/whoami:v1.8.0"},
+			k3d.DockerImage{Name: "coredns/coredns:1.3.1"},
+			k3d.DockerImage{Name: "coredns/coredns:1.4.0"},
+			k3d.DockerImage{Name: "coredns/coredns:1.5.2"},
+			k3d.DockerImage{Name: "coredns/coredns:1.6.3"},
+			k3d.DockerImage{Name: "coredns/coredns:1.7.0"},
+			k3d.DockerImage{Name: "coredns/coredns:1.8.0"},
+			k3d.DockerImage{Name: "coredns/coredns:1.9.0"},
+			k3d.DockerImage{Name: "giantswarm/tiny-tools:3.9"},
+		))
 	}
 
-	s.logger = logrus.New()
-	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName,
-		k3d.WithoutTraefik(),
-		k3d.WithImages(requiredImages...),
-	)
+	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName, opts...)
 	c.Assert(err, checker.IsNil)
 
 	c.Assert(s.cluster.CreateNamespace(s.logger, traefikMeshNamespace), checker.IsNil)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,6 +15,7 @@ import (
 var (
 	integration          = flag.Bool("integration", false, "run integration tests")
 	debug                = flag.Bool("debug", false, "debug log level")
+	disableImport        = flag.Bool("disable-import", false, "disable images import")
 	masterURL            = "https://localhost:8443"
 	k3dClusterName       = "traefik-mesh-integration"
 	traefikMeshNamespace = "traefik-mesh"

--- a/integration/k3d/k3d.go
+++ b/integration/k3d/k3d.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	k3sImage   = "rancher/k3s"
-	k3sVersion = "v1.18.20-k3s1"
+	k3sVersion = "v1.21.14-k3s1"
 )
 
 // DockerImage holds the configuration of a Docker image.
@@ -41,14 +41,14 @@ type ClusterOptionFunc func(opts *ClusterOptions)
 // WithoutTraefik tells k3d to not start a k3s cluster with Traefik already installed in.
 func WithoutTraefik() func(opts *ClusterOptions) {
 	return func(opts *ClusterOptions) {
-		opts.Cmd = append(opts.Cmd, "--k3s-server-arg", "--no-deploy=traefik")
+		opts.Cmd = append(opts.Cmd, "--k3s-arg", "--disable=traefik@server:0")
 	}
 }
 
 // WithoutCoreDNS tells k3d to not start a k3s cluster with CoreDNS already installed in.
 func WithoutCoreDNS() func(opts *ClusterOptions) {
 	return func(opts *ClusterOptions) {
-		opts.Cmd = append(opts.Cmd, "--k3s-server-arg", "--no-deploy=coredns")
+		opts.Cmd = append(opts.Cmd, "--k3s-arg", "--disable=coredns@server:0")
 	}
 }
 

--- a/integration/k3d/k3d.go
+++ b/integration/k3d/k3d.go
@@ -52,8 +52,8 @@ func WithoutCoreDNS() func(opts *ClusterOptions) {
 	}
 }
 
-// WithImages tells k3d to import the given image. Images which are tagged a local won't be pull locally before being
-// imported.
+// WithImages tells k3d to import the given image.
+// Images which are tagged a local won't be pull locally before being imported.
 func WithImages(images ...DockerImage) func(opts *ClusterOptions) {
 	return func(opts *ClusterOptions) {
 		opts.Images = append(opts.Images, images...)
@@ -70,11 +70,7 @@ type Cluster struct {
 
 // NewCluster creates a new k3s cluster using the given configuration.
 func NewCluster(logger logrus.FieldLogger, masterURL string, name string, opts ...ClusterOptionFunc) (*Cluster, error) {
-	clusterOpts := ClusterOptions{
-		Images: []DockerImage{
-			{Name: "rancher/coredns-coredns:1.6.3"},
-		},
-	}
+	var clusterOpts ClusterOptions
 
 	for _, opt := range opts {
 		opt(&clusterOpts)
@@ -330,9 +326,11 @@ func pullDockerImages(logger logrus.FieldLogger, images []DockerImage) error {
 }
 
 func importDockerImages(logger logrus.FieldLogger, clusterName string, images []DockerImage) error {
-	args := []string{
-		"image", "import", "--cluster", clusterName,
+	if len(images) == 0 {
+		return nil
 	}
+
+	args := []string{"image", "import", "--cluster", clusterName}
 
 	for _, image := range images {
 		args = append(args, image.Name)

--- a/integration/kubedns_test.go
+++ b/integration/kubedns_test.go
@@ -23,12 +23,12 @@ func (s *KubeDNSSuite) SetUpSuite(c *check.C) {
 	var err error
 
 	requiredImages := []k3d.DockerImage{
-		{Name: "traefik/whoami:v1.6.0"},
+		{Name: "traefik/whoami:v1.8.0"},
 		{Name: "coredns/coredns:1.6.3"},
 		{Name: "giantswarm/tiny-tools:3.9"},
-		{Name: "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7"},
-		{Name: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7"},
-		{Name: "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7"},
+		{Name: "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.15.13"},
+		{Name: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.15.13"},
+		{Name: "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.15.13"},
 	}
 
 	s.logger = logrus.New()

--- a/integration/kubedns_test.go
+++ b/integration/kubedns_test.go
@@ -22,21 +22,21 @@ type KubeDNSSuite struct {
 func (s *KubeDNSSuite) SetUpSuite(c *check.C) {
 	var err error
 
-	requiredImages := []k3d.DockerImage{
-		{Name: "traefik/whoami:v1.8.0"},
-		{Name: "coredns/coredns:1.6.3"},
-		{Name: "giantswarm/tiny-tools:3.9"},
-		{Name: "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.15.13"},
-		{Name: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.15.13"},
-		{Name: "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.15.13"},
+	s.logger = logrus.New()
+
+	opts := []k3d.ClusterOptionFunc{k3d.WithoutTraefik(), k3d.WithoutCoreDNS()}
+	if !*disableImport {
+		opts = append(opts, k3d.WithImages(
+			k3d.DockerImage{Name: "traefik/whoami:v1.8.0"},
+			k3d.DockerImage{Name: "coredns/coredns:1.6.3"},
+			k3d.DockerImage{Name: "giantswarm/tiny-tools:3.9"},
+			k3d.DockerImage{Name: "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.15.13"},
+			k3d.DockerImage{Name: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.15.13"},
+			k3d.DockerImage{Name: "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.15.13"},
+		))
 	}
 
-	s.logger = logrus.New()
-	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName,
-		k3d.WithoutTraefik(),
-		k3d.WithoutCoreDNS(),
-		k3d.WithImages(requiredImages...),
-	)
+	s.cluster, err = k3d.NewCluster(s.logger, masterURL, k3dClusterName, opts...)
 	c.Assert(err, checker.IsNil)
 
 	c.Assert(s.cluster.CreateNamespace(s.logger, traefikMeshNamespace), checker.IsNil)

--- a/integration/testdata/acl_disabled/http/1.server.yaml
+++ b/integration/testdata/acl_disabled/http/1.server.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: server-http
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_disabled/traffic-split/2.server-v1.yaml
+++ b/integration/testdata/acl_disabled/traffic-split/2.server-v1.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: server-v1
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_disabled/traffic-split/3.server-v2.yaml
+++ b/integration/testdata/acl_disabled/traffic-split/3.server-v2.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: server-v2
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_disabled/udp/1.server.yaml
+++ b/integration/testdata/acl_disabled/udp/1.server.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: server-udp
-      image: traefik/whoamiudp:v0.1.0
+      image: traefik/whoamiudp:v0.1.2
       imagePullPolicy: IfNotPresent
       ports:
         - name: udp

--- a/integration/testdata/acl_enabled/http/1.server.yaml
+++ b/integration/testdata/acl_enabled/http/1.server.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: server
   containers:
     - name: server-http
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_enabled/http/3.server-api.yaml
+++ b/integration/testdata/acl_enabled/http/3.server-api.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: server-api
   containers:
     - name: server-http-api
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_enabled/http/4.server-header.yaml
+++ b/integration/testdata/acl_enabled/http/4.server-header.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: server-header
   containers:
     - name: server-http-header
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/acl_enabled/traffic-split/1.server-split.yaml
+++ b/integration/testdata/acl_enabled/traffic-split/1.server-split.yaml
@@ -26,7 +26,7 @@ spec:
   serviceAccountName: server-split
   containers:
     - name: server-http-split-v1
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:
@@ -63,7 +63,7 @@ spec:
   serviceAccountName: server-split
   containers:
     - name: server-http-split-v2
-      image: traefik/whoami:v1.6.0
+      image: traefik/whoami:v1.8.0
       imagePullPolicy: IfNotPresent
       readinessProbe:
         httpGet:

--- a/integration/testdata/crds/smi-access.yaml
+++ b/integration/testdata/crds/smi-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: traffictargets.access.smi-spec.io
@@ -12,18 +12,157 @@ spec:
       - tt
     plural: traffictargets
     singular: traffictarget
-  version: v1alpha2
   versions:
+    - name: v1alpha3
+      served: false
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - destination
+                - rules
+                - sources
+              properties:
+                destination:
+                  description: The destination of this traffic target.
+                  type: object
+                  required:
+                    - name
+                    - kind
+                  properties:
+                    kind:
+                      description: Kind of the destination.
+                      type: string
+                    name:
+                      description: Name of the destination.
+                      type: string
+                    namespace:
+                      description: Namespace of the destination.
+                      type: string
+                rules:
+                  description: Specifications of this traffic target.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - kind
+                    properties:
+                      kind:
+                        description: Kind of this spec.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                          - TCPRoute
+                          - UDPRoute
+                      name:
+                        description: Name of this spec.
+                        type: string
+                      matches:
+                        description: Match conditions of this spec.
+                        type: array
+                        items:
+                          type: string
+                sources:
+                  description: Sources of this traffic target.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - kind
+                    properties:
+                      kind:
+                        description: Kind of this source.
+                        type: string
+                      name:
+                        description: Name of this source.
+                        type: string
+                      namespace:
+                        description: Namespace of this source.
+                        type: string
     - name: v1alpha2
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - destination
+              properties:
+                destination:
+                  description: The destination of this traffic target.
+                  type: object
+                  required:
+                    - name
+                    - kind
+                  properties:
+                    kind:
+                      description: Kind of the destination.
+                      type: string
+                    name:
+                      description: Name of the destination.
+                      type: string
+                    namespace:
+                      description: Namespace of the destination.
+                      type: string
+                    port:
+                      description: Port number of the destination.
+                      type: number
+                rules:
+                  description: Specifications of this traffic target.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - kind
+                    properties:
+                      kind:
+                        description: Kind of this spec.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                          - TCPRoute
+                      name:
+                        description: Name of this spec.
+                        type: string
+                      matches:
+                        description: Match conditions of this spec.
+                        type: array
+                        items:
+                          type: string
+                sources:
+                  description: Sources of this traffic target.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - kind
+                    properties:
+                      kind:
+                        description: Kind of this source.
+                        type: string
+                      name:
+                        description: Name of this source.
+                        type: string
+                      namespace:
+                        description: Namespace of this source.
+                        type: string
     - name: v1alpha1
       served: false
       storage: false
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+      schema:
+        openAPIV3Schema:
+          type: object
           required:
             - destination
           properties:
@@ -33,6 +172,7 @@ spec:
               required:
                 - name
                 - kind
+                - port
               properties:
                 kind:
                   description: Kind of the destination.
@@ -46,7 +186,7 @@ spec:
                 port:
                   description: Port number of the destination.
                   type: number
-            rules:
+            specs:
               description: Specifications of this traffic target.
               type: array
               items:

--- a/integration/testdata/crds/smi-specs.yaml
+++ b/integration/testdata/crds/smi-specs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: httproutegroups.specs.smi-spec.io
@@ -12,21 +12,163 @@ spec:
       - htr
     plural: httproutegroups
     singular: httproutegroup
-  version: v1alpha3
   versions:
+    - name: v1alpha4
+      served: false
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - matches
+              properties:
+                matches:
+                  description: Match conditions of this route group.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        description: Name of the HTTP route.
+                        type: string
+                      pathRegex:
+                        description: URI path regex of the HTTP route.
+                        type: string
+                      methods:
+                        description: The HTTP methods of this HTTP route.
+                        type: array
+                        items:
+                          type: string
+                          description: The HTTP method of this HTTP route.
+                          enum:
+                            - '*'
+                            - GET
+                            - HEAD
+                            - PUT
+                            - POST
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                      headers:
+                        description: Header match conditions of this route.
+                        type: array
+                        items:
+                          description: Header match condition of this route.
+                          type: object
+                          additionalProperties:
+                            type: string
     - name: v1alpha3
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - matches
+              properties:
+                matches:
+                  description: Match conditions of this route group.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        description: Name of the HTTP route.
+                        type: string
+                      pathRegex:
+                        description: URI path regex of the HTTP route.
+                        type: string
+                      methods:
+                        description: The HTTP methods of this HTTP route.
+                        type: array
+                        items:
+                          type: string
+                          description: The HTTP method of this HTTP route.
+                          enum:
+                            - '*'
+                            - GET
+                            - HEAD
+                            - PUT
+                            - POST
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                      headers:
+                        description: Header match conditions of this route.
+                        type: array
+                        items:
+                          description: Header match condition of this route.
+                          type: object
+                          additionalProperties:
+                            type: string
     - name: v1alpha2
       served: false
       storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - matches
+          properties:
+            matches:
+              description: Match conditions of this route group.
+              type: array
+              items:
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    description: Name of the HTTP route.
+                    type: string
+                  pathRegex:
+                    description: URI path regex of the HTTP route.
+                    type: string
+                  methods:
+                    description: The HTTP methods of this HTTP route.
+                    type: array
+                    items:
+                      type: string
+                      description: The HTTP method of this HTTP route.
+                      enum:
+                        - '*'
+                        - GET
+                        - HEAD
+                        - PUT
+                        - POST
+                        - DELETE
+                        - CONNECT
+                        - OPTIONS
+                        - TRACE
+                        - PATCH
+                  headers:
+                    description: Header match conditions of this route.
+                    type: array
+                    items:
+                      description: Header match condition of this route.
+                      type: object
+                      additionalProperties:
+                        type: string
     - name: v1alpha1
       served: false
       storage: false
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+      schema:
+        openAPIV3Schema:
+          type: object
           required:
             - matches
           properties:
@@ -70,7 +212,7 @@ spec:
                       additionalProperties:
                         type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tcproutes.specs.smi-spec.io
@@ -83,14 +225,36 @@ spec:
       - tr
     plural: tcproutes
     singular: tcproute
-  version: v1alpha3
   versions:
+    - name: v1alpha4
+      served: false
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - matches
+              properties:
+                matches:
+                  description: Match conditions of this route.
+                  type: object
+                  required:
+                    - ports
+                  properties:
+                    ports:
+                      description: Port numbers to match TCP traffic.
+                      type: array
+                      items:
+                        type: integer
     - name: v1alpha3
       served: true
       storage: true
-    - name: v1alpha2
-      served: false
-      storage: false
-    - name: v1alpha1
-      served: false
-      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object

--- a/integration/testdata/crds/smi-split.yaml
+++ b/integration/testdata/crds/smi-split.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: trafficsplits.split.smi-spec.io
@@ -13,59 +13,284 @@ spec:
       - ts
     plural: trafficsplits
     singular: trafficsplit
-  version: v1alpha3
   versions:
+    - name: v1alpha4
+      served: false
+      storage: false
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'kind', 'name' ]
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
     - name: v1alpha3
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'kind', 'name' ]
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
     - name: v1alpha2
       served: false
       storage: false
-    - name: v1alpha1
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: trafficsplits.split.smi-spec.io
+spec:
+  group: split.smi-spec.io
+  scope: Namespaced
+  names:
+    kind: TrafficSplit
+    listKind: TrafficSplitList
+    shortNames:
+      - ts
+    plural: trafficsplits
+    singular: trafficsplit
+  versions:
+    - name: v1alpha4
       served: false
       storage: false
-  additionalPrinterColumns:
-    - name: Service
-      type: string
-      description: The apex service of this split.
-      JSONPath: .spec.service
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
           type: object
-          required:
-            - service
-            - backends
           properties:
-            service:
-              description: The apex service of this split.
-              type: string
-            matches:
-              description: The HTTP route groups that this traffic split should match.
-              type: array
-              items:
-                type: object
-                required: ['kind', 'name']
-                properties:
-                  kind:
-                    description: Kind of the matching group.
-                    type: string
-                    enum:
-                      - HTTPRouteGroup
-                  name:
-                    description: Name of the matching group.
-                    type: string
-            backends:
-              description: The backend services of this split.
-              type: array
-              items:
-                type: object
-                required: ['service', 'weight']
-                properties:
-                  service:
-                    description: Name of the Kubernetes service.
-                    type: string
-                  weight:
-                    description: Traffic weight value of this backend.
-                    type: number
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'kind', 'name' ]
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
+    - name: v1alpha3
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                matches:
+                  description: The HTTP route groups that this traffic split should match.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'kind', 'name' ]
+                    properties:
+                      kind:
+                        description: Kind of the matching group.
+                        type: string
+                        enum:
+                          - HTTPRouteGroup
+                      name:
+                        description: Name of the matching group.
+                        type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number
+    - name: v1alpha2
+      served: false
+      storage: false
+      additionalPrinterColumns:
+        - name: Service
+          type: string
+          description: The apex service of this split.
+          jsonPath: .spec.service
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - service
+                - backends
+              properties:
+                service:
+                  description: The apex service of this split.
+                  type: string
+                backends:
+                  description: The backend services of this split.
+                  type: array
+                  items:
+                    type: object
+                    required: [ 'service', 'weight' ]
+                    properties:
+                      service:
+                        description: Name of the Kubernetes service.
+                        type: string
+                      weight:
+                        description: Traffic weight value of this backend.
+                        type: number

--- a/integration/testdata/kubedns/coredns.yaml
+++ b/integration/testdata/kubedns/coredns.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: traefik-mesh
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -31,7 +31,7 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:

--- a/integration/testdata/kubedns/kubedns.yaml
+++ b/integration/testdata/kubedns/kubedns.yaml
@@ -93,7 +93,7 @@ spec:
             optional: true
       containers:
         - name: kubedns
-          image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+          image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.15.13
           resources:
             # TODO: Set memory limits when we've profiled the container for large
             # clusters, then set request = limit to keep this container in
@@ -144,7 +144,7 @@ spec:
             - name: kube-dns-config
               mountPath: /kube-dns-config
         - name: dnsmasq
-          image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+          image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.15.13
           livenessProbe:
             httpGet:
               path: /healthcheck/dnsmasq
@@ -183,7 +183,7 @@ spec:
             - name: kube-dns-config
               mountPath: /etc/k8s/dns/dnsmasq-nanny
         - name: sidecar
-          image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+          image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.15.13
           livenessProbe:
             httpGet:
               path: /metrics

--- a/integration/testdata/traefik-mesh/controller-acl-disabled.yaml
+++ b/integration/testdata/traefik-mesh/controller-acl-disabled.yaml
@@ -10,7 +10,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-controller-role
   namespace: traefik-mesh
@@ -68,7 +68,7 @@ rules:
       - watch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-controller
   namespace: traefik-mesh

--- a/integration/testdata/traefik-mesh/controller-acl-enabled.yaml
+++ b/integration/testdata/traefik-mesh/controller-acl-enabled.yaml
@@ -10,7 +10,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-controller-role
   namespace: traefik-mesh
@@ -68,7 +68,7 @@ rules:
       - watch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-controller
   namespace: traefik-mesh

--- a/integration/testdata/traefik-mesh/proxy.yaml
+++ b/integration/testdata/traefik-mesh/proxy.yaml
@@ -11,7 +11,7 @@ automountServiceAccountToken: false
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-proxy-role
   namespace: traefik-mesh
@@ -28,7 +28,7 @@ rules:
       - list
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-mesh-proxy
   namespace: traefik-mesh

--- a/integration/tool/tool.go
+++ b/integration/tool/tool.go
@@ -93,7 +93,7 @@ func (t *Tool) Netcat(url string, port int, udp bool, conditions ...try.StringCo
 	if udp {
 		cmd = fmt.Sprintf("echo 'WHO' | nc -u -w 1 %s %d", url, port)
 	} else {
-		cmd = fmt.Sprintf("echo 'WHO' | nc -q 0 %s %d", url, port)
+		cmd = fmt.Sprintf("echo 'WHO' | nc -q 0 -w 1 %s %d", url, port)
 	}
 
 	output, err := t.exec([]string{"ash", "-c", cmd})


### PR DESCRIPTION
## What does this PR do?

This pull request updates the k3d version to `v5.4.4` to be able to run the integration tests locally. 

Because of an issue in k3d, it is not possible to import `amd64` images in a cluster on Apple Silicon. For that reason, the new `--disable-import` flag can be leveraged to run the integration tests on M1 machines.

```shell
$ TESTFLAGS="--disable-import" make test-integration
```
