### PR TITLE
chore: update copyright text 2023

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,7 +28,7 @@ theme:
     prev: 'Previous'
     next: 'Next'
 
-copyright: "Copyright &copy; 2020-2022 Traefik Labs"
+copyright: 'Traefik Labs • Copyright &copy; 2016-2023'
 
 extra_javascript:
   - assets/js/hljs/highlight.pack.js # Download from https://highlightjs.org/download/ and enable YAML, TOML and Dockerfile


### PR DESCRIPTION
## What does this PR do?

Changes the Copyright text in the documentation.

![Screenshot 2022-12-21 at 22 23 17](https://user-images.githubusercontent.com/38889364/209034435-5cbdced0-6f37-4788-b332-b873c3a5ac49.png)


### How to test it

- Navigate to the `/docs` directory
- Run `make serve`
- Check the documentation at `http://0.0.0.0:8000/traefik-mesh/`

## Additional Notes

- The year of the copyright is already set for 2023
