### PR TITLE
chore(ci): exclude old doc branches from structor build

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/traefik/mixtus/master/godownloader.sh | sh -s -- -b $HOME/bin ${MIXTUS_VERSION}
 
       - name: Build documentation
-        run: $HOME/bin/structor -o traefik -r mesh --dockerfile-url="https://raw.githubusercontent.com/traefik/mesh/master/docs/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/traefik/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/traefik/structor/master/requirements-override.txt" --force-edit-url --exp-branch=master --debug
+        run: $HOME/bin/structor -o traefik -r mesh --dockerfile-url="https://raw.githubusercontent.com/traefik/mesh/master/docs/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/traefik/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/traefik/structor/master/requirements-override.txt" --force-edit-url --exp-branch=master --exclude=v1.0 --exclude=v1.1 --exclude=v1.2 --exclude=v1.3 --debug
         env:
           STRUCTOR_LATEST_TAG: ${{ secrets.STRUCTOR_LATEST_TAG }}
 


### PR DESCRIPTION
# Description
Exclude branches v1.0 through v1.3 from structor doc builds. These branches use Alpine 3.10 / Python 3.7 / pip 20.1.1 which can no longer install current pip dependencies (`AttributeError: cython_sources`).

This should fix the failing [last build](https://github.com/traefik/mesh/actions/runs/23441325506/job/68192777100).